### PR TITLE
feat: added weekDayStartOn

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Download the latest release from the [releases page](https://github.com/leoanang
 | `showSelectWeekends` | Boolean | `true` | Show "Select Weekends" button (multiple/multi-range modes) |
 | `showSelectAllDays` | Boolean | `true` | Show "Select All Days" button (multiple/multi-range modes) |
 | `dualCalendar` | Boolean | `true` | Show Dual Calendar |
+| `weekDayStartOn` | Number | `0` | First day of the week: `0` = Sunday, `1` = Monday, ..., `6` = Saturday |
 
 ### Date Restrictions
 
@@ -231,6 +232,15 @@ new FlexiDatepicker('#datepicker', {
   dateFormat: 'd/M/yyyy',
   showClearAll: true,
   showSelectWeekdays: false
+});
+```
+
+### Week Starting on Monday
+
+```javascript
+new FlexiDatepicker('#datepicker', {
+  mode: 'single',
+  weekDayStartOn: 1 // Monday
 });
 ```
 

--- a/src/flexidatepicker.js
+++ b/src/flexidatepicker.js
@@ -31,6 +31,7 @@ export default class FlexiDatepicker {
             minDate: null,
             maxDate: null,
             dualCalendar: false,
+            weekDayStartOn: 0, // 0 = Sunday, 1 = Monday, ..., 6 = Saturday
             ...options,
         }
 
@@ -92,7 +93,7 @@ export default class FlexiDatepicker {
 
         const weekdayFormatter = new Intl.DateTimeFormat(this.options.locale, { weekday: "short" })
         const weekdayHeaders = []
-        const tempDate = new Date(2020, 5, 7)
+        const tempDate = new Date(2020, 5, 7 + this.options.weekDayStartOn)
         for (let i = 0; i < 7; i++) {
             const dayName = weekdayFormatter.format(
                 new Date(tempDate.getFullYear(), tempDate.getMonth(), tempDate.getDate() + i),
@@ -424,8 +425,9 @@ export default class FlexiDatepicker {
 
         const firstDayOfMonth = new Date(year, month, 1).getDay()
         const daysInMonth = new Date(year, month + 1, 0).getDate()
+        const startOffset = (firstDayOfMonth - this.options.weekDayStartOn + 7) % 7
 
-        for (let i = 0; i < firstDayOfMonth; i++) {
+        for (let i = 0; i < startOffset; i++) {
             const emptyCell = document.createElement("div")
             emptyCell.classList.add("mrdp-day-cell", "empty")
             grid.appendChild(emptyCell)


### PR DESCRIPTION
👋 👋 

### **Add weekDayStartOn prop to customize week start day**

**Summary**

1. Adds a new weekDayStartOn option to configure which day the calendar week starts on
2. Accepts values 0-6 where 0 = Sunday (default), 1 = Monday, ..., 6 = Saturday
3. Useful for locales where Monday is the first day of the week
4. Updated readme

**Usage**

// Start week on Monday
```
const picker = new FlexiDatepicker('#date-input', {
    weekDayStartOn: 1
});
```

**Changes**

1. Added weekDayStartOn option with default value 0 (Sunday)
2. Updated weekday header generation to start from the configured day
3. Adjusted calendar grid rendering to correctly position days based on week start